### PR TITLE
Allow A/B comparison for patch being edited

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,16 +1,9 @@
 import React from 'react'
-import { connect } from 'react-redux'
 import './app.css'
 import FmSynth from './fm-synth/FmSynth'
 import DOMPush from './push/DOMPush'
-import { activeGridSelect, activePads, gridPadPressed, gridSelectPressed } from './push'
 
-const mapStateToProps = state => ({
-  activeGridSelect: activeGridSelect(state),
-  activePads: activePads(state)
-})
-
-const App = ({ activeGridSelect, activePads, gridPadPressed, gridSelectPressed }) => (
+const App = () => (
   <>
     <h1>Push FM</h1>
     <FmSynth />
@@ -18,4 +11,4 @@ const App = ({ activeGridSelect, activePads, gridPadPressed, gridSelectPressed }
   </>
 )
 
-export default connect(mapStateToProps, { gridPadPressed, gridSelectPressed })(App)
+export default App

--- a/src/app.css
+++ b/src/app.css
@@ -5,6 +5,14 @@
   max-width: 52.5rem;
 }
 
+h1 {
+  margin-bottom: 0;
+}
+
+.fm-synth {
+  margin-top: 0.5em;
+}
+
 .push-body {
   margin: auto;
   background: grey;
@@ -72,4 +80,12 @@
 
 .synth-control__label {
   display: block;
+}
+
+.synth-control-select, .synth-control-button {
+  cursor: pointer;
+  font-size: 0.9rem;
+  margin: 0.5em 0.5em 0.5em 0;
+  min-width: 10em;
+  padding: 0.25em;
 }

--- a/src/fm-synth/FmSynth.js
+++ b/src/fm-synth/FmSynth.js
@@ -1,6 +1,11 @@
 import React from 'react'
 import { connect } from 'react-redux'
 import {
+  bringBackA,
+  bringBackB,
+  currentPatchHasEdits,
+  currentPatchHasModifiedVersion,
+  currentPatchNumber,
   env1Attack, updateEnv1Attack,
   env1Decay, updateEnv1Decay,
   env1Release, updateEnv1Release,
@@ -11,13 +16,20 @@ import {
   env2Sustain, updateEnv2Sustain,
   harmonicityLevel, updateHarmonicityLevel,
   harmonicityLevelEnv2Amount, updateHarmonicityLevelEnv2Amount,
+  loadPatch,
   modLevel, updateModLevel,
-  modLevelEnv2Amount, updateModLevelEnv2Amount
+  modLevelEnv2Amount, updateModLevelEnv2Amount,
+  savePatch
 } from './index'
+import range from '../range'
 
 const forEvent = action => event => action(event.target.value)
+const forEventWithIntValue = action => event => action(parseInt(event.target.value))
 
 const mapStateToProps = state => ({
+  currentPatchHasEdits: currentPatchHasEdits(state),
+  currentPatchHasModifiedVersion: currentPatchHasModifiedVersion(state),
+  currentPatchNumber: currentPatchNumber(state),
   env1Attack: env1Attack(state),
   env1Decay: env1Decay(state),
   env1Release: env1Release(state),
@@ -41,6 +53,11 @@ const Parameter = ({ label, id = idFrom(label), update, value }) => (
 )
 
 const FmSynth = ({
+  bringBackA,
+  bringBackB,
+  currentPatchHasEdits,
+  currentPatchHasModifiedVersion,
+  currentPatchNumber,
   env1Attack,
   env1Decay,
   env1Release,
@@ -51,8 +68,10 @@ const FmSynth = ({
   env2Sustain,
   harmonicityLevel,
   harmonicityLevelEnv2Amount,
+  loadPatch,
   modLevel,
   modLevelEnv2Amount,
+  savePatch,
   updateEnv1Attack,
   updateEnv1Decay,
   updateEnv1Release,
@@ -67,6 +86,28 @@ const FmSynth = ({
   updateModLevelEnv2Amount
 }) => (
   <div class="fm-synth">
+    <div>
+      <span>Current patch</span>
+      <select onChange={loadPatch} value={currentPatchNumber}>
+        {range(1, 8).map(x => (
+          <option value={x}>{x}</option>
+        ))}
+      </select>
+      <button style={{ background: !currentPatchHasEdits ? 'red' : '' }} disabled={!currentPatchHasEdits} onClick={bringBackA} >A</button>
+      <button style={{ background: currentPatchHasEdits ? 'red' : '' }} disabled={!currentPatchHasModifiedVersion} onClick={bringBackB}>B</button>
+      <div>
+        <span>save</span>
+        {range(1, 8).map(x => (
+          <button
+            disabled={!currentPatchHasEdits}
+            onClick={() => savePatch(x)}
+            style={{ background: (x === currentPatchNumber) ? 'blue' : '' }}
+          >
+            {x}
+          </button>
+        ))}
+      </div>
+    </div>
     <div>
       <Parameter label="Mod level" update={updateModLevel} value={modLevel} />
       <Parameter label="Env 2 amount" update={updateModLevelEnv2Amount} value={modLevelEnv2Amount} />
@@ -93,6 +134,10 @@ const FmSynth = ({
 export default connect(
   mapStateToProps,
   {
+    bringBackA: bringBackA,
+    bringBackB: bringBackB,
+    loadPatch: forEventWithIntValue(loadPatch),
+    savePatch,
     updateEnv1Attack: forEvent(updateEnv1Attack),
     updateEnv1Decay: forEvent(updateEnv1Decay),
     updateEnv1Release: forEvent(updateEnv1Release),

--- a/src/fm-synth/FmSynth.js
+++ b/src/fm-synth/FmSynth.js
@@ -17,9 +17,8 @@ import {
   loadPatch,
   modLevel, updateModLevel,
   modLevelEnv2Amount, updateModLevelEnv2Amount,
-  reapplyPatchModifications,
-  revertPatchModifications,
-  savePatch
+  savePatch,
+  togglePatchAB
 } from './index'
 import range from '../range'
 
@@ -69,9 +68,8 @@ const FmSynth = ({
   loadPatch,
   modLevel,
   modLevelEnv2Amount,
-  reapplyPatchModifications,
-  revertPatchModifications,
   savePatch,
+  togglePatchAB,
   updateEnv1Attack,
   updateEnv1Decay,
   updateEnv1Release,
@@ -95,12 +93,14 @@ const FmSynth = ({
         <option>Save as patch number...</option>
         {range(1, 8).map(x => <option value={x} >{x}</option>)}
       </select>
-      {currentPatchIsModified && (
-        <button onClick={revertPatchModifications}>Revert modifications</button>
-      )}
-      {currentPatchHasModifiedVersion && (
-        <button onClick={reapplyPatchModifications}>Re-apply modifications</button>
-      )}
+    </div>
+    <div>
+      <span>
+        {!currentPatchIsModified || currentPatchHasModifiedVersion ? <strong>A</strong> : 'A'}
+        &nbsp;|&nbsp;
+        {currentPatchIsModified ? <strong>B</strong> : currentPatchHasModifiedVersion ? 'B' : <em>B</em>}
+      </span>
+      <button onClick={togglePatchAB} disabled={!currentPatchIsModified && !currentPatchHasModifiedVersion}>Toggle patch A | B</button>
     </div>
     <div>
       <Parameter label="Mod level" update={updateModLevel} value={modLevel} />
@@ -129,9 +129,8 @@ export default connect(
   mapStateToProps,
   {
     loadPatch: forEventWithIntValue(loadPatch),
-    reapplyPatchModifications: reapplyPatchModifications,
-    revertPatchModifications: revertPatchModifications,
     savePatch: forEventWithIntValue(savePatch),
+    togglePatchAB: togglePatchAB,
     updateEnv1Attack: forEvent(updateEnv1Attack),
     updateEnv1Decay: forEvent(updateEnv1Decay),
     updateEnv1Release: forEvent(updateEnv1Release),

--- a/src/fm-synth/FmSynth.js
+++ b/src/fm-synth/FmSynth.js
@@ -89,24 +89,21 @@ const FmSynth = ({
     <div>
       <span>Current patch</span>
       <select onChange={loadPatch} value={currentPatchNumber}>
-        {range(1, 8).map(x => (
-          <option value={x}>{x}</option>
-        ))}
+        {range(1, 8).map(x => <option value={x}>{x}</option>)}
       </select>
-      <button style={{ background: !currentPatchHasEdits ? 'red' : '' }} disabled={!currentPatchHasEdits} onClick={bringBackA} >A</button>
-      <button style={{ background: currentPatchHasEdits ? 'red' : '' }} disabled={!currentPatchHasModifiedVersion} onClick={bringBackB}>B</button>
-      <div>
-        <span>save</span>
-        {range(1, 8).map(x => (
-          <button
-            disabled={!currentPatchHasEdits}
-            onClick={() => savePatch(x)}
-            style={{ background: (x === currentPatchNumber) ? 'blue' : '' }}
-          >
-            {x}
-          </button>
-        ))}
-      </div>
+      <select
+        onChange={e => { e.target.value && savePatch(e) }}
+        value=""
+      >
+        <option>Save as patch number...</option>
+        {range(1, 8).map(x => <option value={x} >{x}</option>)}
+      </select>
+      {currentPatchHasEdits && (
+        <button onClick={bringBackA}>Revert modifications</button>
+      )}
+      {currentPatchHasModifiedVersion && (
+        <button onClick={bringBackB}>Re-apply modifications</button>
+      )}
     </div>
     <div>
       <Parameter label="Mod level" update={updateModLevel} value={modLevel} />
@@ -137,7 +134,7 @@ export default connect(
     bringBackA: bringBackA,
     bringBackB: bringBackB,
     loadPatch: forEventWithIntValue(loadPatch),
-    savePatch,
+    savePatch: forEventWithIntValue(savePatch),
     updateEnv1Attack: forEvent(updateEnv1Attack),
     updateEnv1Decay: forEvent(updateEnv1Decay),
     updateEnv1Release: forEvent(updateEnv1Release),

--- a/src/fm-synth/FmSynth.js
+++ b/src/fm-synth/FmSynth.js
@@ -45,9 +45,15 @@ const mapStateToProps = state => ({
 
 const idFrom = label => label.toLowerCase().replace(/\s+/g, '-')
 const Parameter = ({ label, id = idFrom(label), update, value }) => (
+  <SynthControl id={id} label={label}>
+    <input type="range" id={id} onChange={update} min="0" max="1.0" step="0.001" value={value} />
+  </SynthControl>
+)
+
+const SynthControl = ({ children, label, id = idFrom(label) }) => (
   <div class="synth-control">
     <label class="synth-control__label" for={id}>{label}</label>
-    <input type="range" id={id} onChange={update} min="0" max="1.0" step="0.001" value={value} />
+    {children}
   </div>
 )
 
@@ -85,22 +91,29 @@ const FmSynth = ({
 }) => (
   <div class="fm-synth">
     <div>
-      <span>Current patch:</span>
-      <select onChange={loadPatch} value={currentPatchNumber}>
-        {range(1, 8).map(x => <option value={x}>{x}</option>)}
-      </select>
-      <select onChange={savePatch} value="" >
-        <option>Save as patch number...</option>
-        {range(1, 8).map(x => <option value={x} >{x}</option>)}
-      </select>
-    </div>
-    <div>
-      <span>
-        {!currentPatchIsModified || currentPatchHasModifiedVersion ? <strong>A</strong> : 'A'}
-        &nbsp;|&nbsp;
-        {currentPatchIsModified ? <strong>B</strong> : currentPatchHasModifiedVersion ? 'B' : <em>B</em>}
-      </span>
-      <button onClick={togglePatchAB} disabled={!currentPatchIsModified && !currentPatchHasModifiedVersion}>Toggle patch A | B</button>
+      <SynthControl id="load-patch" label="Current patch" >
+        <select id="load-patch" class="synth-control-select" onChange={loadPatch} value={currentPatchNumber}>
+          {range(1, 8).map(x => <option value={x}>{x}</option>)}
+        </select>
+      </SynthControl>
+      <SynthControl
+        id="toggle-a-b"
+        label={(
+          <>
+            {!currentPatchIsModified || currentPatchHasModifiedVersion ? <strong>A</strong> : 'A'}
+            &nbsp;|&nbsp;
+            {currentPatchIsModified ? <strong>B</strong> : currentPatchHasModifiedVersion ? 'B' : <em>B</em>}
+          </>
+        )}
+      >
+        <button id="toggle-a-b" class="synth-control-button" onClick={togglePatchAB} disabled={!currentPatchIsModified && !currentPatchHasModifiedVersion}>Toggle patch A | B</button>
+      </SynthControl>
+      <SynthControl id="save-patch" label="" >
+        <select id="save-patch" class="synth-control-select" onChange={savePatch} value="" >
+          <option>Save as patch number...</option>
+          {range(1, 8).map(x => <option value={x} >{x}</option>)}
+        </select>
+      </SynthControl>
     </div>
     <div>
       <Parameter label="Mod level" update={updateModLevel} value={modLevel} />

--- a/src/fm-synth/FmSynth.js
+++ b/src/fm-synth/FmSynth.js
@@ -1,10 +1,8 @@
 import React from 'react'
 import { connect } from 'react-redux'
 import {
-  bringBackA,
-  bringBackB,
-  currentPatchHasEdits,
   currentPatchHasModifiedVersion,
+  currentPatchIsModified,
   currentPatchNumber,
   env1Attack, updateEnv1Attack,
   env1Decay, updateEnv1Decay,
@@ -19,16 +17,18 @@ import {
   loadPatch,
   modLevel, updateModLevel,
   modLevelEnv2Amount, updateModLevelEnv2Amount,
+  reapplyPatchModifications,
+  revertPatchModifications,
   savePatch
 } from './index'
 import range from '../range'
 
 const forEvent = action => event => action(event.target.value)
-const forEventWithIntValue = action => event => action(parseInt(event.target.value))
+const forEventWithIntValue = action => event => event.target.value && action(parseInt(event.target.value))
 
 const mapStateToProps = state => ({
-  currentPatchHasEdits: currentPatchHasEdits(state),
   currentPatchHasModifiedVersion: currentPatchHasModifiedVersion(state),
+  currentPatchIsModified: currentPatchIsModified(state),
   currentPatchNumber: currentPatchNumber(state),
   env1Attack: env1Attack(state),
   env1Decay: env1Decay(state),
@@ -53,10 +53,8 @@ const Parameter = ({ label, id = idFrom(label), update, value }) => (
 )
 
 const FmSynth = ({
-  bringBackA,
-  bringBackB,
-  currentPatchHasEdits,
   currentPatchHasModifiedVersion,
+  currentPatchIsModified,
   currentPatchNumber,
   env1Attack,
   env1Decay,
@@ -71,6 +69,8 @@ const FmSynth = ({
   loadPatch,
   modLevel,
   modLevelEnv2Amount,
+  reapplyPatchModifications,
+  revertPatchModifications,
   savePatch,
   updateEnv1Attack,
   updateEnv1Decay,
@@ -87,22 +87,19 @@ const FmSynth = ({
 }) => (
   <div class="fm-synth">
     <div>
-      <span>Current patch</span>
+      <span>Current patch:</span>
       <select onChange={loadPatch} value={currentPatchNumber}>
         {range(1, 8).map(x => <option value={x}>{x}</option>)}
       </select>
-      <select
-        onChange={e => { e.target.value && savePatch(e) }}
-        value=""
-      >
+      <select onChange={savePatch} value="" >
         <option>Save as patch number...</option>
         {range(1, 8).map(x => <option value={x} >{x}</option>)}
       </select>
-      {currentPatchHasEdits && (
-        <button onClick={bringBackA}>Revert modifications</button>
+      {currentPatchIsModified && (
+        <button onClick={revertPatchModifications}>Revert modifications</button>
       )}
       {currentPatchHasModifiedVersion && (
-        <button onClick={bringBackB}>Re-apply modifications</button>
+        <button onClick={reapplyPatchModifications}>Re-apply modifications</button>
       )}
     </div>
     <div>
@@ -131,9 +128,9 @@ const FmSynth = ({
 export default connect(
   mapStateToProps,
   {
-    bringBackA: bringBackA,
-    bringBackB: bringBackB,
     loadPatch: forEventWithIntValue(loadPatch),
+    reapplyPatchModifications: reapplyPatchModifications,
+    revertPatchModifications: revertPatchModifications,
     savePatch: forEventWithIntValue(savePatch),
     updateEnv1Attack: forEvent(updateEnv1Attack),
     updateEnv1Decay: forEvent(updateEnv1Decay),

--- a/src/fm-synth/__tests__/patch-management-spec.js
+++ b/src/fm-synth/__tests__/patch-management-spec.js
@@ -120,6 +120,15 @@ describe('patch management', () => {
         expect(currentPatchHasModifiedVersion(getState())).toEqual(false)
       })
 
+      it('is not possible on modifying a patch then reverting to the "A" version, then modifying again', async () => {
+        const { dispatch, getState } = await createStore()
+        dispatch(updateModLevel(0.5))
+        dispatch(revertPatchModifications())
+        dispatch(updateModLevel(0.75))
+
+        expect(currentPatchHasModifiedVersion(getState())).toEqual(false)
+      })
+
       it('is not possible on modifying a patch then reverting to the "A" version, then saving the patch', async () => {
         const { dispatch, getState } = await createStore()
         dispatch(updateModLevel(0.5))

--- a/src/fm-synth/__tests__/patch-management-spec.js
+++ b/src/fm-synth/__tests__/patch-management-spec.js
@@ -1,4 +1,13 @@
-import { loadPatch, modLevel, savePatch, updateModLevel } from '..'
+import {
+  currentPatchHasModifiedVersion,
+  currentPatchIsModified,
+  loadPatch,
+  modLevel,
+  reapplyPatchModifications,
+  revertPatchModifications,
+  savePatch,
+  updateModLevel
+} from '..'
 import createStore from '../../store'
 
 describe('patch management', () => {
@@ -35,5 +44,90 @@ describe('patch management', () => {
     dispatch(loadPatch(2))
     dispatch(loadPatch(1))
     expect(modLevel(getState())).toEqual(0)
+  })
+
+  describe('A/B comparison', () => {
+    describe('reverting to the unedited "A" version of a patch', () => {
+      it('is not possible on loading patch', async () => {
+        const { getState } = await createStore()
+
+        expect(currentPatchIsModified(getState())).toEqual(false)
+      })
+
+      it('is possible after modifying a patch', async () => {
+        const { dispatch, getState } = await createStore()
+        dispatch(updateModLevel(0.5))
+
+        expect(currentPatchIsModified(getState())).toEqual(true)
+      })
+
+      it('is not possible after modifying a patch then saving it', async () => {
+        const { dispatch, getState } = await createStore()
+        dispatch(updateModLevel(0.5))
+        dispatch(savePatch(1))
+
+        expect(currentPatchIsModified(getState())).toEqual(false)
+      })
+
+      it('is not possible after modifying a patch then loading a different one it', async () => {
+        const { dispatch, getState } = await createStore()
+        dispatch(updateModLevel(0.5))
+
+        // patch 1 not saved
+        dispatch(loadPatch(2))
+
+        expect(currentPatchIsModified(getState())).toEqual(false)
+      })
+    })
+
+    describe('(re-)applying the edited "B" version of a patch', () => {
+      it('is not possible on loading patch', async () => {
+        const { getState } = await createStore()
+
+        expect(currentPatchHasModifiedVersion(getState())).toEqual(false)
+      })
+
+      it('is not possible on modifying a patch', async () => {
+        const { dispatch, getState } = await createStore()
+        dispatch(updateModLevel(0.5))
+
+        expect(currentPatchHasModifiedVersion(getState())).toEqual(false)
+      })
+
+      it('is possible on modifying a patch then reverting to the "A" version', async () => {
+        const { dispatch, getState } = await createStore()
+        dispatch(updateModLevel(0.5))
+        dispatch(revertPatchModifications())
+
+        expect(currentPatchHasModifiedVersion(getState())).toEqual(true)
+      })
+
+      it('is not possible on modifying a patch then reverting to the "A" version, then re-applying the "B" version', async () => {
+        const { dispatch, getState } = await createStore()
+        dispatch(updateModLevel(0.5))
+        dispatch(revertPatchModifications())
+        dispatch(reapplyPatchModifications())
+
+        expect(currentPatchHasModifiedVersion(getState())).toEqual(false)
+      })
+
+      it('is not possible on modifying a patch then reverting to the "A" version, then loading another patch', async () => {
+        const { dispatch, getState } = await createStore()
+        dispatch(updateModLevel(0.5))
+        dispatch(revertPatchModifications())
+        dispatch(loadPatch(2))
+
+        expect(currentPatchHasModifiedVersion(getState())).toEqual(false)
+      })
+
+      it('is not possible on modifying a patch then reverting to the "A" version, then saving the patch', async () => {
+        const { dispatch, getState } = await createStore()
+        dispatch(updateModLevel(0.5))
+        dispatch(revertPatchModifications())
+        dispatch(savePatch(1))
+
+        expect(currentPatchHasModifiedVersion(getState())).toEqual(false)
+      })
+    })
   })
 })

--- a/src/fm-synth/index.js
+++ b/src/fm-synth/index.js
@@ -114,6 +114,7 @@ export const reducer = (state = initialState, action) => {
       return {
         ...state,
         patchHasEdits: true,
+        modifiedPatch: undefined,
         patch: { ...state.patch, [action.param]: Math.max(0, Math.min(1, action.delta + state.patch[[action.param]])) }
       }
     case 'FM_SYNTH_INITIALISE':
@@ -132,6 +133,7 @@ export const reducer = (state = initialState, action) => {
       return {
         ...state,
         patchHasEdits: true,
+        modifiedPatch: undefined,
         patch: { ...state.patch, [action.param]: action.level }
       }
     case 'FM_SYNTH_LOAD_PATCH':

--- a/src/fm-synth/index.js
+++ b/src/fm-synth/index.js
@@ -27,12 +27,12 @@ export const updateModLevelEnv2Amount = level => updateParam('modLevelEnv2Amount
 const updateParam = (param, level) => ({ type: 'FM_SYNTH_UPDATE_PARAM', param, level: parseFloat(level) })
 
 // ---------- SELECTOR ----------
-const activeNotes = state => state.fmSynth.activeNotes
+const activeNotes = state => fmSynth(state).activeNotes
 export const currentActiveNoteNumbers = state => activeNotes(state).map(({ noteNumber }) => noteNumber)
-const currentPatch = state => state.fmSynth.patch
+const currentPatch = state => fmSynth(state).patch
 export const currentPatchNumber = (state) => patchManagement(state).currentPatchNumber
-export const currentPatchHasModifiedVersion = (state) => !!state.fmSynth.modifiedPatch
-export const currentPatchIsModified = (state) => state.fmSynth.patchHasEdits
+export const currentPatchHasModifiedVersion = (state) => !!modifiedPatch(state)
+export const currentPatchIsModified = (state) => fmSynth(state).patchHasEdits
 export const env1Attack = state => currentPatch(state).env1Attack
 export const env1Decay = state => currentPatch(state).env1Decay
 export const env1Release = state => currentPatch(state).env1Release
@@ -41,9 +41,11 @@ export const env2Attack = state => currentPatch(state).env2Attack
 export const env2Decay = state => currentPatch(state).env2Decay
 export const env2Release = state => currentPatch(state).env2Release
 export const env2Sustain = state => currentPatch(state).env2Sustain
+const fmSynth = state => state.fmSynth
+const modifiedPatch = state => fmSynth(state).modifiedPatch
 export const modLevel = state => currentPatch(state).modLevel
 export const modLevelEnv2Amount = state => currentPatch(state).modLevelEnv2Amount
-export const numberOfVoices = state => state.fmSynth.numberOfVoices
+export const numberOfVoices = state => fmSynth(state).numberOfVoices
 export const harmonicityLevel = state => currentPatch(state).harmonicityLevel
 export const harmonicityLevelEnv2Amount = state => currentPatch(state).harmonicityLevelEnv2Amount
 const patchManagement = state => state.patchManagement
@@ -240,7 +242,7 @@ export const createMiddleware = () => {
         next(action)
         return
       case 'FM_SYNTH_REAPPLY_PATCH_MODIFICATIONS':
-        action.patch = getState().fmSynth.modifiedPatch
+        action.patch = modifiedPatch(getState())
         next(action)
         return
       case 'FM_SYNTH_SAVE_PATCH':

--- a/src/fm-synth/index.js
+++ b/src/fm-synth/index.js
@@ -8,10 +8,11 @@ const noteOff = voice => ({ type: 'FM_SYNTH_NOTE_OFF', voice })
 const noteOn = (noteNumber, velocity, voice) => ({ type: 'FM_SYNTH_NOTE_ON', noteNumber, velocity, voice })
 export const playNote = (noteNumber, velocity) => ({ type: 'FM_SYNTH_PLAY_NOTE', noteNumber, velocity, autoRelease: false })
 export const playNoteAndRelease = (noteNumber, velocity) => ({ type: 'FM_SYNTH_PLAY_NOTE', noteNumber, velocity, autoRelease: true })
-export const reapplyPatchModifications = () => ({ type: 'FM_SYNTH_REAPPLY_PATCH_MODIFICATIONS' })
+const reapplyPatchModifications = () => ({ type: 'FM_SYNTH_REAPPLY_PATCH_MODIFICATIONS' })
 export const releaseNote = noteNumber => ({ type: 'FM_SYNTH_RELEASE_NOTE', noteNumber })
-export const revertPatchModifications = () => ({ type: 'FM_SYNTH_REVERT_PATCH_MODIFICATIONS' })
+const revertPatchModifications = () => ({ type: 'FM_SYNTH_REVERT_PATCH_MODIFICATIONS' })
 export const savePatch = patchNumber => ({ type: 'FM_SYNTH_SAVE_PATCH', patchNumber })
+export const togglePatchAB = () => ({ type: 'FM_SYNTH_TOGGLE_A_B' })
 export const updateEnv1Attack = level => updateParam('env1Attack', level)
 export const updateEnv1Decay = level => updateParam('env1Decay', level)
 export const updateEnv1Release = level => updateParam('env1Release', level)
@@ -250,6 +251,14 @@ export const createMiddleware = () => {
       case 'FM_SYNTH_SAVE_PATCH':
         action.patch = currentPatch(getState())
         return next(action)
+      case 'FM_SYNTH_TOGGLE_A_B':
+        if (currentPatchIsModified(getState())) {
+          return dispatch(revertPatchModifications())
+        }
+        if (currentPatchHasModifiedVersion(getState())) {
+          return dispatch(reapplyPatchModifications())
+        }
+        return
     }
     return next(action)
   }


### PR DESCRIPTION
A/B patches to compare edits with saved version

<img width="868" alt="Screenshot 2020-07-03 at 15 33 31" src="https://user-images.githubusercontent.com/4037089/86479704-90069e00-bd44-11ea-89fb-2ac4c98c4337.png">

Note no ability to do this from the Push